### PR TITLE
update version, aws cloud front link, RI name

### DIFF
--- a/Casks/redis-stack-redisinsight.rb
+++ b/Casks/redis-stack-redisinsight.rb
@@ -1,5 +1,5 @@
 cask "redis-stack-redisinsight" do
-  version "2.0,5"
+  version "2.0.5"
   name "RedisInsight"
   desc "A graphical tool for visualizing data and managing Redis databases"
   homepage "https://redis.com/redis-enterprise/redis-insight/"
@@ -16,7 +16,7 @@ cask "redis-stack-redisinsight" do
     end
   end
 
-  url "https://s3.amazonaws.com/redisinsight.test/public/rs-ri-builds/#{version}/redisstack/RedisInsight-preview-app-#{baseos}.#{platform}.tar.gz"
+  url "https://download-test.redisinsight.redis.com/rs-ri-builds/#{version}/redisstack/RedisInsight-v2-app-#{baseos}.#{platform}.tar.gz"
   app "RedisInsight-preview.app"
 
   uninstall_preflight do
@@ -37,7 +37,7 @@ cask "redis-stack-redisinsight" do
     dest = "#{basepath}/redisinsight"
     File.open(dest, 'w+') { |f|
       f.write("#!/bin/sh\n\n")
-      f.write("open /Applications/RedisInsight-preview.app\n")
+      f.write("open /Applications/RedisInsight-v2.app\n")
     }
     FileUtils.chmod(0755, dest)
   end


### PR DESCRIPTION
Changes:
* updated version
* instead of s3 link we can use Cloud front link (https://download-test.redisinsight.redis.com)
* today RedisInsight was renamed from -preview to -v2