### PR TITLE
Add a formula that allows redis-stack-server to be run as a service

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,9 +10,9 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
-
   x86_64:
     name: Validate x86_64
     runs-on: macos-13
@@ -25,7 +25,36 @@ jobs:
       - name: run redis-stack
         run:
           /usr/local/bin/redis-stack-server -h &
-      - name: try to redis-stack
+      - name: try to ping redis-stack
+        run:
+          redis-cli ping
+
+  x86_64_service:
+    name: Validate x86_64 service
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: test in the installations
+        run: |
+          brew install --cask Casks/redis-stack-server.rb
+          brew install --formula Formula/redis-stack-service.rb
+          brew services start redis-stack-service
+      - name: wait for redis-stack service to start
+        run: |
+          attempt=1
+          max_attempts=10
+          sleep_time=2
+          until redis-cli ping 2>/dev/null || [ $attempt -gt $max_attempts ]
+          do
+            echo "Waiting for Redis Stack to start (attempt $attempt/$max_attempts)..."
+            sleep $sleep_time
+            attempt=$((attempt+1))
+          done
+          if [ $attempt -gt $max_attempts ]; then
+            echo "Redis Stack failed to start after $max_attempts attempts"
+            exit 1
+          fi
+      - name: try to ping redis-stack
         run:
           redis-cli ping
 
@@ -41,6 +70,35 @@ jobs:
       - name: run redis-stack
         run:
           /opt/homebrew/bin/redis-stack-server -h &
-      - name: try to redis-stack
+      - name: try to ping redis-stack
+        run:
+          redis-cli ping
+
+  arm64_service:
+    name: Validate arm64 service
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: test in the installations
+        run: |
+          brew install --cask Casks/redis-stack-server.rb
+          brew install --formula Formula/redis-stack-service.rb
+          brew services start redis-stack-service
+      - name: wait for redis-stack service to start
+        run: |
+          attempt=1
+          max_attempts=10
+          sleep_time=2
+          until redis-cli ping 2>/dev/null || [ $attempt -gt $max_attempts ]
+          do
+            echo "Waiting for Redis Stack to start (attempt $attempt/$max_attempts)..."
+            sleep $sleep_time
+            attempt=$((attempt+1))
+          done
+          if [ $attempt -gt $max_attempts ]; then
+            echo "Redis Stack failed to start after $max_attempts attempts"
+            exit 1
+          fi
+      - name: try to ping redis-stack
         run:
           redis-cli ping

--- a/Casks/redis-stack.rb
+++ b/Casks/redis-stack.rb
@@ -1,13 +1,13 @@
 cask "redis-stack" do
   version "7.4.0-v3"
-  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-  # FIXME: PLACEHOLDER
-  url "https://redismodules.s3.amazonaws.com/redis-stack/.donotremove"
+  url "file:///dev/null"
+  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   name "Redis Stack"
   desc "Redis server with additional database capabilities and the visualisation tool RedisInsight"
   homepage "https://redis.io/"
 
   depends_on cask: "redis-stack-server"
   depends_on cask: "redis-stack-redisinsight"
+  depends_on formula: "redis-stack-service"
 end

--- a/Formula/redis-stack-service.rb
+++ b/Formula/redis-stack-service.rb
@@ -1,0 +1,59 @@
+class RedisStackService < Formula
+  desc "Service wrapper for redis-stack-server cask"
+  homepage "https://redis.io/"
+  version "7.4.0-v3"
+
+  url "file:///dev/null"
+  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+  def install
+    (buildpath/"README.md").write <<~EOS
+      # redis-stack-server service
+      This formula provides a service for the redis-stack-server cask.
+    EOS
+
+    (buildpath/"redis-stack-service").write <<~EOS
+      #!/bin/bash
+      CASK_BIN="#{HOMEBREW_PREFIX}/bin/redis-stack-server"
+      CASK_CONF="#{HOMEBREW_PREFIX}/etc/redis-stack.conf"
+      
+      if [ ! -f "$CASK_BIN" ]; then
+        echo "Error: redis-stack-server binary not found at $CASK_BIN"
+        echo "Please install with: brew install --cask redis-stack-server"
+        exit 1
+      fi
+      
+      if [ ! -f "$CASK_CONF" ]; then
+        echo "Error: redis-stack.conf not found at $CASK_CONF"
+        echo "Please install with: brew install --cask redis-stack-server"
+        exit 1
+      fi
+      
+      exec "$CASK_BIN" "$CASK_CONF" "$@"
+    EOS
+
+    bin.install "redis-stack-service"
+    chmod 0755, bin/"redis-stack-service"
+    
+    prefix.install "README.md"
+
+    (var/"db/redis-stack").mkpath
+    (var/"log").mkpath
+    (var/"run").mkpath
+  end
+
+  service do
+    run [opt_bin/"redis-stack-service"]
+    keep_alive true
+    error_log_path var/"log/redis-stack.log"
+    log_path var/"log/redis-stack.log"
+    working_dir var
+  end
+
+  def post_install
+    unless File.exist?("#{HOMEBREW_PREFIX}/bin/redis-stack-server")
+      ohai "redis-stack-server cask is not installed"
+      ohai "Please install it with: brew install --cask redis-stack-server"
+    end
+  end
+end 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,77 @@
 [![.github/workflows/integration.yml](https://github.com/redis-stack/homebrew-redis-stack/actions/workflows/integration.yml/badge.svg)](https://github.com/redis-stack/homebrew-redis-stack/actions/workflows/integration.yml)
 
-# redis-stack homebrew
+# Homebrew Tap for redis-stack
 
-## Installation
+## Quick Installation
 
-Enable the repostiory:
+To enable the tap and install Redis Stack server and RedisInsight:
 
+```sh
+brew tap redis-stack/redis-stack
+brew install --cask redis-stack
 ```
+
+To start a background service for `redis-stack-server` so that it starts in the background now and on login:
+
+```sh
+brew services start redis-stack-service
+```
+
+## Configuration
+
+By default redis-stack will have no password, Redis Stack supports the ability to configure multiple named users, each with their own password and access control configuration. Refer to the [Redis Access Control List documentation](https://redis.io/docs/management/security/acl/) for more information. Alternatively the configuration file can be edited and the *requirepass* directive added.
+
+## Manual Installation
+
+If you only want to install certain components, first enable the tap:
+
+```sh
 brew tap redis-stack/redis-stack
 ```
 
-Install redis-stack
+### Install redis-stack-server (Cask)
 
+```sh
+brew install --cask redis-stack-server
 ```
-brew install --cask redis-stack
+
+### Install redis-stack-redisinsight (Cask)
+
+```sh
+brew install --cask redis-stack-redisinsight
+```
+
+### Service support for redis-stack-server (Formula)
+
+To run redis-stack-server as a service, install the formula:
+
+```sh
+brew install redis-stack-service
+brew services start redis-stack-service
 ```
 
 ## Upgrading
 
-To upgrade redis-stack server:
+To upgrade the components:
 
-```
-brew upgrade redis-stack-server
-```
-
-To upgrade redisinsight:
-
-```
-brew upgrade redis-stack-redisinsight
+```sh
+brew upgrade --cask redis-stack-server
+brew upgrade --cask redis-stack-redisinsight
 ```
 
-By default redis-stack will have no password, Redis Stack supports the ability to configure multiple named users, each with their own password and access control configuration.  Refer to the [Redis Access Control List documentation](https://redis.io/docs/management/security/acl/) for more information. Alternatively the configuration file can be edited and the *requirepass* directive added.
+## Uninstalling
+
+You must uninstall each component separately:
+
+```sh
+brew uninstall --cask redis-stack
+brew uninstall --cask redis-stack-server
+brew uninstall --cask redis-stack-redisinsight
+brew uninstall redis-stack-service
+```
+
+You may then remove the tap:
+
+```sh
+brew untap redis-stack/redis-stack
+```


### PR DESCRIPTION
I've wanted to be able to run redis-stack-server as a service using `brew services`, and this PR implements that by adding a wrapper formula that calls into the redis-stack-server cask binary. I also improved the README a little bit and added instructions for starting the service.

I agree to the contributor license agreement provided at https://github.com/redis/redis/blob/eafc365040014d587df45d57467de3f86363111e/CONTRIBUTING.md
/Richard Henry/